### PR TITLE
Update glass.dm

### DIFF
--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -224,13 +224,16 @@
 	name = "bluespace beaker"
 	desc = "A bluespace beaker, powered by experimental bluespace technology \
 		and Element Cuban combined with the Compound Pete. Can hold up to \
-		300 units. Unable to withstand reagents of an extreme pH."
+		300 units. Able to withstand reagents of an extreme pH."
 	icon_state = "beakerbluespace"
 	materials = list(MAT_GLASS=3000)
 	volume = 300
 	amount_per_transfer_from_this = 10
 	possible_transfer_amounts = list(5,10,15,20,25,30,50,100,300)
 	container_HP = 5
+/obj/item/reagent_containers/glass/beaker/bluespace/Initialize() // Lumos change
+	beaker_weakness_bitflag &= ~PH_WEAK
+	. = ..()
 
 /obj/item/reagent_containers/glass/beaker/cryoxadone
 	list_reagents = list(/datum/reagent/medicine/cryoxadone = 30)


### PR DESCRIPTION
## About The Pull Request

Makes removes the PH_WEAK flag from bluespace beakers

## Why It's Good For The Game

Makes the bluespace beakers viable for reactions requiring extreme PH values, it didn't make much sense for them not to be in the first place considering their cost.

## Changelog
:cl:
tweak: PH proofed bluespace beakers
/:cl: