### PR TITLE
Fixes Calcic conflicting with the Bloodsucker language

### DIFF
--- a/lumos/code/languages/calcic.dm
+++ b/lumos/code/languages/calcic.dm
@@ -5,7 +5,7 @@
 	ask_verb = "queries"
 	exclaim_verb = "screeches"
 	whisper_verb = "clicks"
-	key = "b"
+	key = "q"
 	flags = TONGUELESS_SPEECH
 	space_chance = 10
 	syllables = list(


### PR DESCRIPTION
## About The Pull Request

Changed the key from b to q so there'd be no issues knowing both bloodsucker and calcic

## Why It's Good For The Game

It's a fix

## Changelog
fix: assigned calcic to q to avoid conflicts with bloodsucker
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
