### PR TITLE
Telecomm Engineer Addition

### DIFF
--- a/code/game/objects/effects/landmarks.dm
+++ b/code/game/objects/effects/landmarks.dm
@@ -147,6 +147,10 @@ INITIALIZE_IMMEDIATE(/obj/effect/landmark)
 	name = "Station Engineer"
 	icon_state = "Station Engineer"
 
+	/obj/effect/landmark/start/telecommunications_engineer
+	name = "Telecommunications Engineer"
+	icon_state = "Station Engineer"
+
 /obj/effect/landmark/start/medical_doctor
 	name = "Medical Doctor"
 	icon_state = "Medical Doctor"

--- a/code/modules/jobs/job_types/telecommunications_engineer.dm
+++ b/code/modules/jobs/job_types/telecommunications_engineer.dm
@@ -1,0 +1,54 @@
+/datum/job/telecommunications_engineer
+	title = "Telecommunications Engineer"
+	flag = ENGINEER
+	department_head = list("Chief Engineer")
+	department_flag = ENGSEC
+	faction = "Station"
+	total_positions = 1
+	spawn_positions = 1
+	supervisors = "the chief engineer"
+	selection_color = "#ff9b3d"
+	exp_requirements = 60
+	exp_type = EXP_TYPE_CREW
+
+	outfit = /datum/outfit/job/engineer
+
+	access = list(ACCESS_ENGINE, ACCESS_ENGINE_EQUIP, ACCESS_TECH_STORAGE, ACCESS_MAINT_TUNNELS,
+									ACCESS_EXTERNAL_AIRLOCKS, ACCESS_CONSTRUCTION, ACCESS_ATMOSPHERICS, ACCESS_TCOMSAT, ACCESS_MINERAL_STOREROOM)
+	minimal_access = list(ACCESS_ENGINE, ACCESS_ENGINE_EQUIP, ACCESS_TECH_STORAGE, ACCESS_MAINT_TUNNELS,
+									ACCESS_EXTERNAL_AIRLOCKS, ACCESS_CONSTRUCTION, ACCESS_TCOMSAT, ACCESS_MINERAL_STOREROOM)
+
+	display_order = JOB_DISPLAY_ORDER_STATION_ENGINEER
+
+/datum/outfit/job/engineer
+	name = "Telecommunications Engineer"
+	jobtype = /datum/job/telecommunications_engineer
+
+	belt = /obj/item/storage/belt/utility/full/engi
+	l_pocket = /obj/item/pda/engineering
+	r_pocket = /obj/item/paper/monitorkey
+	ears = /obj/item/radio/headset/headset_eng
+	uniform = /obj/item/clothing/under/rank/engineer
+	shoes = /obj/item/clothing/shoes/workboots
+	suit = /obj/item/clothing/suit/hooded/wintercoat/engineering
+
+	backpack = /obj/item/storage/backpack/industrial
+	satchel = /obj/item/storage/backpack/satchel/eng
+	duffelbag = /obj/item/storage/backpack/duffelbag/engineering
+	box = /obj/item/storage/box/engineer
+	pda_slot = SLOT_L_STORE
+	backpack_contents = list(/obj/item/modular_computer/tablet/preset/advanced=1)
+
+/datum/outfit/job/engineer/gloved
+	name = "Station Engineer (Gloves)"
+	gloves = /obj/item/clothing/gloves/color/yellow
+
+/datum/outfit/job/engineer/gloved/rig
+	name = "Station Engineer (Hardsuit)"
+	mask = /obj/item/clothing/mask/breath
+	suit = /obj/item/clothing/suit/space/hardsuit/engine
+	suit_store = /obj/item/tank/internals/oxygen
+	head = null
+	internals_slot = SLOT_S_STORE
+
+

--- a/code/modules/jobs/jobs.dm
+++ b/code/modules/jobs/jobs.dm
@@ -10,6 +10,7 @@ GLOBAL_LIST_INIT(command_positions, list(
 GLOBAL_LIST_INIT(engineering_positions, list(
 	"Chief Engineer",
 	"Station Engineer",
+	"Telecommunications Engineer",
 	"Atmospheric Technician"))
 
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

+Adds the Telecomm Engineer job
+Adds the Telecomm Engineer landmark for spawning roundstart (Needs to be mapped in.)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

For fixing T-comms in case of damage, notifying people when comms are down, and watching telecomm logs for anomalies.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Added T-comm engineer job.
add: Added T-comm engineer landmark.

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
